### PR TITLE
fix(gatsby-source-strapi): value could be in string format

### DIFF
--- a/packages/gatsby-source-strapi/src/download-media-files.js
+++ b/packages/gatsby-source-strapi/src/download-media-files.js
@@ -121,7 +121,8 @@ const extractImages = async (item, context, uid) => {
 
     if (value && type) {
       if (type === "richtext") {
-        const extractedFiles = extractFiles(value.data, apiURL);
+        const richText = value.data ? value.data : value;
+        const extractedFiles = extractFiles(richText, apiURL);
 
         const files = await Promise.all(
           extractedFiles.map(async ({ url }) => {


### PR DESCRIPTION
## Description

Since richtext property might actually be in string format, I add a fallback to add more resilience to the code.

## Related Issues

Fixes #383
